### PR TITLE
コンポーネントへのスタイル適用をCSS Moduleで行う

### DIFF
--- a/src/stories/atoms/Button/Button.tsx
+++ b/src/stories/atoms/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "./button.css";
+import styles from "./button.module.css";
 
 interface ButtonProps {
   primary?: boolean;
@@ -19,13 +19,18 @@ export const Button: React.FC<ButtonProps> = ({
   handleClick,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? "a-button--primary" : "a-button--secondary";
-  const radius = isRadius && "a-button--radius";
+  const mode = primary ? styles.a_button__primary : styles.a_button__secondary;
+  const radius = isRadius && styles.a_button__radius;
 
   return (
     <button
       type='button'
-      className={["a-button", `a-button--${size}`, mode, radius].join(" ")}
+      className={[
+        styles.a_button,
+        styles[`a_button__${size}`],
+        mode,
+        radius,
+      ].join(" ")}
       style={{ backgroundColor }}
       {...props}
       onClick={handleClick}

--- a/src/stories/atoms/Button/button.module.css
+++ b/src/stories/atoms/Button/button.module.css
@@ -1,4 +1,4 @@
-.a-button {
+.a_button {
   font-family: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 700;
   border: 0;
@@ -7,40 +7,40 @@
   line-height: 1;
 }
 
-.a-button--primary {
+.a_button__primary {
   color: white;
   background-color: #1ea7fd;
 }
 
-.a-button--primary:hover {
+.a_button__primary:hover {
   background-color: #1391cc;
 }
 
-.a-button--secondary {
+.a_button__secondary {
   color: #333;
   background-color: transparent;
   box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
 }
 
-.a-button--secondary:hover {
+.a_button__secondary:hover {
   box-shadow: rgba(0, 0, 0, 0.2) 0px 0px 0px 1.5px inset;
 }
 
-.a-button--small {
+.a_button__small {
   font-size: 12px;
   padding: 10px 16px;
 }
 
-.a-button--medium {
+.a_button__medium {
   font-size: 14px;
   padding: 11px 20px;
 }
 
-.a-button--large {
+.a_button__large {
   font-size: 16px;
   padding: 12px 24px;
 }
 
-.a-button--radius {
+.a_button__radius {
   border-radius: 3em;
 }

--- a/src/stories/atoms/Tag/TagContainer.tsx
+++ b/src/stories/atoms/Tag/TagContainer.tsx
@@ -1,4 +1,4 @@
-import "./tag.css";
+import styles from "./tag.module.css";
 import TagPresentational from "./TagPresentational";
 
 type TagContainerProps = {
@@ -18,8 +18,8 @@ const TagContainer: React.FC<TagContainerProps> = ({
   label,
   onClick,
 }) => {
-  const mode = primary ? "a-tag--primary" : "a-tag--secondary";
-  const ovaled = oval ? "a-tag--oval" : undefined;
+  const mode = primary ? styles.a_tag__primary : styles.a_tag__secondary;
+  const ovaled = oval ? styles.a_tag__oval : undefined;
 
   return (
     <TagPresentational

--- a/src/stories/atoms/Tag/TagPresentational.tsx
+++ b/src/stories/atoms/Tag/TagPresentational.tsx
@@ -1,4 +1,4 @@
-import "./tag.css";
+import styles from "./tag.module.css";
 
 type TagPresentationalProps = {
   backgroundColor?: string;
@@ -19,8 +19,10 @@ const TagPresentational: React.FC<TagPresentationalProps> = ({
 }) => {
   return (
     <button
-      type="button"
-      className={["a-tag", `a-tag--${size}`, mode, ovaled].join(" ")}
+      type='button'
+      className={[styles.a_tag, styles[`a_tag__${size}`], mode, ovaled].join(
+        " "
+      )}
       style={{ backgroundColor }}
       onClick={handleOnClick}
     >

--- a/src/stories/atoms/Tag/tag.module.css
+++ b/src/stories/atoms/Tag/tag.module.css
@@ -1,4 +1,4 @@
-.a-tag {
+.a_tag {
   display: inline-block;
   margin: 0 0.1em 0.6em 0;
   padding: 0.6em;
@@ -7,34 +7,34 @@
   color: #7d7d7d;
 }
 
-.a-tag:before {
+.a_tag:before {
   content: "#";
   margin-right: 2px;
 }
 
-.a-tag--primary {
+.a_tag__primary {
   color: #274a78;
   background-color: #fff;
   border: 1px solid #274a78;
 }
-.a-tag--secondary {
+.a_tag__secondary {
   background-color: #fff;
   border: 1px solid #7d7d7d;
 }
 
-.a-tag--oval {
+.a_tag__oval {
   border-radius: 2em;
 }
 
-.a-tag--small {
+.a_tag__small {
   font-size: 12px;
   padding: 10px 16px;
 }
-.a-tag--medium {
+.a_tag__medium {
   font-size: 14px;
   padding: 11px 20px;
 }
-.a-tag--large {
+.a_tag__large {
   font-size: 16px;
   padding: 12px 24px;
 }

--- a/src/stories/molecules/Accordion/Accordion.tsx
+++ b/src/stories/molecules/Accordion/Accordion.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/stories/utlils/animations";
 import React, { PropsWithChildren, useEffect, useRef } from "react";
 import AccordionPresentational from "./AccordionPresentational";
+import styles from "./accordion.module.css";
 
 export interface AccordionContainerProps {
   primary?: boolean;
@@ -12,12 +13,14 @@ export interface AccordionContainerProps {
   duration?: number;
 }
 
-const IS_OPENED_CLASS = "m-accordion--opened";
+const IS_OPENED_CLASS = styles.m_accordion__opened;
 
 const AccordionContainer: React.FC<
   AccordionContainerProps & PropsWithChildren
 > = ({ primary = true, label, duration = 300, children }) => {
-  const mode = primary ? "m-accordion--primary" : "m-accordion--secondary";
+  const mode = primary
+    ? styles.m_accordion__primary
+    : styles.m_accordion__secondary;
   const contentRef = useRef<HTMLDivElement>(null);
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
 

--- a/src/stories/molecules/Accordion/AccordionPresentational.tsx
+++ b/src/stories/molecules/Accordion/AccordionPresentational.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from "react";
-import "./accordion.css";
+import styles from "./accordion.module.css";
 import { AccordionContainerProps } from "./Accordion";
 
 interface AccordionPresentationalProps extends AccordionContainerProps {
@@ -18,15 +18,18 @@ const AccordionPresentational: React.FC<
   children,
 }) => {
   return (
-    <details className={["m-accordion", mode].join(" ")}>
-      <summary className='m-accordion__summary' onClick={handleSummaryClick}>
-        <span className='m-accordion__summary-inner'>
+    <details className={[styles.m_accordion, mode].join(" ")}>
+      <summary
+        className={styles.m_accordion__summary}
+        onClick={handleSummaryClick}
+      >
+        <span className={styles.m_accordion__summary_inner}>
           {label}
-          <span className='m-accordion__icon'></span>
+          <span className={styles.m_accordion__icon}></span>
         </span>
       </summary>
-      <div className='m-accordion__content' ref={contentRef}>
-        <div className='m-accordion__content-inner'>{children}</div>
+      <div className={styles.m_accordion__content} ref={contentRef}>
+        <div className={styles.m_accordion__content_inner}>{children}</div>
       </div>
     </details>
   );

--- a/src/stories/molecules/Accordion/accordion.module.css
+++ b/src/stories/molecules/Accordion/accordion.module.css
@@ -1,23 +1,23 @@
-.m-accordion {
+.m_accordion {
   width: 100%;
 }
 
-.m-accordion__summary {
+.m_accordion__summary {
   display: block;
 }
 
-.m-accordion__summary::-webkit-details-marker {
+.m_accordion__summary::-webkit-details-marker {
   display: none;
 }
 
-.m-accordion__heading {
+.m_accordion__heading {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 }
 
-.m-accordion__summary-inner {
+.m_accordion__summary_inner {
   cursor: pointer;
   display: flex;
   flex-direction: row;
@@ -27,43 +27,43 @@
   font-weight: bold;
 }
 
-.m-accordion--primary .m-accordion__summary-inner {
+.m_accordion__primary .m_accordion__summary_inner {
   border: 1px solid #d2beff;
   color: #002255;
 }
 
-.m-accordion--secondary .m-accordion__summary-inner {
+.m_accordion__secondary .m_accordion__summary_inner {
   border: 1px solid #cccccc;
   color: #333333;
 }
 
-.m-accordion__icon {
+.m_accordion__icon {
   display: block;
   position: relative;
   width: 24px;
   margin-left: 6px;
   flex-shrink: 0;
-  transform-origin: center 43%;
+  transform_origin: center 43%;
   transition: transform 0.4s;
   transition: transform 0.4s;
 }
 
-.m-accordion--opened .m-accordion__icon {
+.m_accordion__opened .m_accordion__icon {
   transform: rotate(180deg);
 }
 
-.m-accordion__icon::before {
+.m_accordion__icon::before {
   left: 0;
   transform: rotate(45deg);
 }
 
-.m-accordion__icon::after {
+.m_accordion__icon::after {
   right: 0;
   transform: rotate(-45deg);
 }
 
-.m-accordion__icon::before,
-.m-accordion__icon::after {
+.m_accordion__icon::before,
+.m_accordion__icon::after {
   content: "";
   position: absolute;
   display: block;
@@ -71,29 +71,29 @@
   height: 3px;
 }
 
-.m-accordion--primary .m-accordion__icon::before,
-.m-accordion__icon::after {
+.m_accordion__primary .m_accordion__icon::before,
+.m_accordion__icon::after {
   background-color: #7050ff;
 }
 
-.m-accordion--secondary .m-accordion__icon::before,
-.m-accordion--secondary .m-accordion__icon::after {
+.m_accordion__secondary .m_accordion__icon::before,
+.m_accordion__secondary .m_accordion__icon::after {
   background-color: #666666;
 }
 
-.m-accordion__content {
+.m_accordion__content {
   overflow: hidden;
 }
 
-.m-accordion--primary .m-accordion__content {
+.m_accordion__primary .m_accordion__content {
   background-color: #f0f2ff;
 }
 
-.m-accordion--secondary .m-accordion__content {
+.m_accordion__secondary .m_accordion__content {
   background-color: #e6e6e6;
 }
 
-.m-accordion__content-inner {
+.m_accordion__content_inner {
   padding: 24px 48px;
   display: flex;
   flex-direction: column;

--- a/src/stories/molecules/FileInput/FileInputContainer.tsx
+++ b/src/stories/molecules/FileInput/FileInputContainer.tsx
@@ -1,5 +1,4 @@
 import { ChangeEventHandler, useRef } from "react";
-import "./file-input.css";
 import FileInputPresentational from "./FileInputPresentational";
 
 export interface FileInputContainerProps {

--- a/src/stories/molecules/FileInput/FileInputPresentational.tsx
+++ b/src/stories/molecules/FileInput/FileInputPresentational.tsx
@@ -1,5 +1,5 @@
 import { ChangeEventHandler } from "react";
-import "./file-input.css";
+import styles from "./file-input.module.css";
 import { FileInputContainerProps } from "./FileInputContainer";
 
 interface FileInputPresentationalProps extends FileInputContainerProps {
@@ -18,13 +18,13 @@ const FileInputPresentational: React.FC<FileInputPresentationalProps> = ({
 }) => {
   return (
     <>
-      <div className='m-file-input'>
+      <div className={styles.m_file_input}>
         {heading && (
-          <div className='m-file-input__heading'>
-            <label htmlFor='m-file-input__button'>{heading}</label>
+          <div className={styles.m_file_input__heading}>
+            <label htmlFor={styles.m_file_input__button}>{heading}</label>
           </div>
         )}
-        <div className='m-file-input__content'>
+        <div className={styles.m_file_input__content}>
           <input
             type='file'
             style={{ display: "none" }}
@@ -32,8 +32,8 @@ const FileInputPresentational: React.FC<FileInputPresentationalProps> = ({
             onChange={handleFileSelect}
           />
           <button
-            className='m-file-input__button'
-            id='m-file-input__button'
+            className={styles.m_file_input__button}
+            id={styles.m_file_input__button}
             onClick={handleButtonClick}
           >
             <img src='/file.svg' className='logo' alt='file logo' />
@@ -41,7 +41,7 @@ const FileInputPresentational: React.FC<FileInputPresentationalProps> = ({
           </button>
         </div>
         {message && (
-          <div className='m-file-input__message'>
+          <div className={styles.m_file_input__message}>
             <span>{message}</span>
           </div>
         )}

--- a/src/stories/molecules/FileInput/file-input.module.css
+++ b/src/stories/molecules/FileInput/file-input.module.css
@@ -1,10 +1,10 @@
-.m-file-input__heading {
+.m_file_input__heading {
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 4px;
 }
 
-.m-file-input__button {
+.m_file_input__button {
   cursor: pointer;
   align-items: center;
   background-color: #fff;
@@ -17,7 +17,7 @@
   padding: 4px 12px;
 }
 
-.m-file-input__message {
+.m_file_input__message {
   color: rgb(45, 64, 72);
   font-size: 12px;
   margin-top: 4px;

--- a/src/stories/organisms/Modal/Modal.stories.ts
+++ b/src/stories/organisms/Modal/Modal.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import parse from "html-react-parser";
-import "./modal.css";
 
 import Modal from "./ModalContainer";
 import { fn } from "@storybook/test";

--- a/src/stories/organisms/Modal/ModalPresentational.tsx
+++ b/src/stories/organisms/Modal/ModalPresentational.tsx
@@ -3,6 +3,7 @@ import ReactModal from "react-modal";
 import closeLogo from "@/assets/close.svg";
 import { Button } from "@/stories/atoms/Button/Button";
 import { ModalProps } from "./ModalContainer";
+import styles from "./modal.module.css";
 
 interface ModalPresentationalProps extends ModalProps {
   showModal: boolean;
@@ -27,9 +28,9 @@ const ModalPresentational: React.FC<
   handleCloseModal,
 }) => {
   return (
-    <div className='o-modal'>
+    <div className={styles.o_modal}>
       {isOpenButton && (
-        <span className='o-modal__ok_button'>
+        <span className={styles.o_modal__ok_button}>
           <Button primary handleClick={handleOpenModal} label={openLabel} />
         </span>
       )}
@@ -37,14 +38,18 @@ const ModalPresentational: React.FC<
         isOpen={showModal}
         onRequestClose={handleCloseModal}
         contentLabel='Modal'
-        className='o-modal__contents'
-        overlayClassName='o-modal__overlay'
+        className={styles.o_modal__contents}
+        overlayClassName={{
+          base: styles.o_modal__overlay,
+          afterOpen: styles.o_modal__overlay__open,
+          beforeClose: styles.o_modal__overlay__before_open,
+        }}
         ariaHideApp={false}
       >
         {isCloseButton && (
           <button
             type='button'
-            className='o-modal__close_button'
+            className={styles.o_modal__close_button}
             onClick={handleCloseModal}
           >
             <img src={closeLogo} alt='close button' height={16} width={16} />
@@ -54,14 +59,14 @@ const ModalPresentational: React.FC<
         {children}
 
         {(isCancelButton || isOkButton) && (
-          <div className='o-modal__button_wrapper'>
+          <div className={styles.o_modal__button_wrapper}>
             {isCancelButton && (
-              <span className='o-modal__cancel_button'>
+              <span className={styles.o_modal__cancel_button}>
                 <Button handleClick={handleCloseModal} label={cancelLabel} />
               </span>
             )}
             {isOkButton && (
-              <span className='o-modal__ok_button'>
+              <span className={styles.o_modal__ok_button}>
                 <Button primary handleClick={handleOK} label={okLabel} />
               </span>
             )}

--- a/src/stories/organisms/Modal/modal.module.css
+++ b/src/stories/organisms/Modal/modal.module.css
@@ -1,4 +1,4 @@
-.o-modal__contents {
+.o_modal__contents {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -12,7 +12,7 @@
   outline: transparent;
 }
 
-.o-modal__overlay {
+.o_modal__overlay {
   position: fixed;
   top: 0;
   right: 0;
@@ -24,21 +24,25 @@
   z-index: 999;
 }
 
-.ReactModal__Overlay--after-open.o-modal__overlay {
+.o_modal__overlay__before_open {
+  opacity: 0;
+}
+
+.o_modal__overlay__open {
   opacity: 1;
 }
 
-.o-modal__ok_button {
+.o_modal__ok_button {
   margin-top: 16px;
   margin-right: 8px;
 }
 
-.o-modal__cancel_button {
+.o_modal__cancel_button {
   margin-top: 16px;
   margin-right: 8px;
 }
 
-.o-modal__close_button {
+.o_modal__close_button {
   position: absolute;
   top: 10px;
   right: 10px;
@@ -48,7 +52,7 @@
   cursor: pointer;
 }
 
-.o-modal__button_wrapper {
+.o_modal__button_wrapper {
   display: flex;
   justify-content: flex-end;
 }

--- a/src/stories/pages/NotFound/NotFound.tsx
+++ b/src/stories/pages/NotFound/NotFound.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import "./not_found.css";
+import styles from "./not_found.module.css";
 
 type NotFoundProps = {
   title?: string;
@@ -16,11 +16,11 @@ const NotFound: React.FC<NotFoundProps> = ({
   linkText = "Site Top",
 }) => {
   return (
-    <div className='p-not-found'>
+    <div className={styles.p_not_found}>
       <h1>{title}</h1>
       <p>{message}</p>
       {link && (
-        <a href={link} className='p-not-found__top-link'>
+        <a href={link} className={styles.p_not_found__top_link}>
           {linkText}
         </a>
       )}

--- a/src/stories/pages/NotFound/not_found.module.css
+++ b/src/stories/pages/NotFound/not_found.module.css
@@ -1,11 +1,11 @@
-.p-not-found {
+.p_not_found {
   text-align: center;
   max-width: 1280px;
   padding: 2rem;
   margin: 0 auto;
 }
 
-.p-not-found__top-link {
+.p_not_found__top_link {
   display: block;
   text-align: center;
 }


### PR DESCRIPTION
# 概要
コンポーネントへのスタイル方法をCSS Moduleに変更しました。
※ アプリケーション移行時に手間がかかるため

- [x] [🎨 Button](https://github.com/PenPeen/react_storybook/commit/ec2e39256f497a69fb06b2bfb6733c90b9207d64)
- [x] [🎨 Tag](https://github.com/PenPeen/react_storybook/commit/601f31ca1cc4dcaaa5224b0edbe20b605efc403f)
- [x] [🎨 Accordion](https://github.com/PenPeen/react_storybook/commit/bd0e0b91cc14476627bcc1a64d9f4f50c601b11e)
- [x] [🎨 FileInput](https://github.com/PenPeen/react_storybook/commit/0a4ec4a146ade07bad82be6b1fd19ff5b508b4fe)
- [x] [🎨 Modal](https://github.com/PenPeen/react_storybook/commit/cb5057cd89f65adf117093d0e1717056d130fcce)
- [x] [🎨 NotFound](https://github.com/PenPeen/react_storybook/commit/6c55c504a4c76dd9d32cde284a76e068c024460e)




