### PR TITLE
:zap: Buttonコンポーネントでwidth: 100%が指定できるように

### DIFF
--- a/src/stories/atoms/Button/Button.stories.ts
+++ b/src/stories/atoms/Button/Button.stories.ts
@@ -70,3 +70,10 @@ export const Radius: Story = {
     isRadius: true,
   },
 };
+
+export const Full: Story = {
+  args: {
+    label: "Button",
+    isFull: true,
+  }
+}

--- a/src/stories/atoms/Button/Button.tsx
+++ b/src/stories/atoms/Button/Button.tsx
@@ -9,6 +9,7 @@ interface ButtonProps {
   label: string;
   isRadius?: boolean;
   isSolid?: boolean;
+  isFull?: boolean;
   isDisabled?: boolean;
   handleClick?: () => void;
 }
@@ -19,12 +20,14 @@ export const Button: React.FC<ButtonProps> = ({
   label,
   isRadius = false,
   isSolid = false,
+  isFull = false,
   isDisabled = false,
   handleClick,
 }: ButtonProps) => {
   const mode = styles[`a_button__${type}`];
   const solid = isSolid && styles[`a_button__${type}_solid`];
   const radius = isRadius && styles.a_button__radius;
+  const full = isFull && styles.a_button__full;
 
   return (
     <button
@@ -36,6 +39,7 @@ export const Button: React.FC<ButtonProps> = ({
         mode,
         solid,
         radius,
+        full
       ].join(" ")}
       onClick={handleClick}
     >

--- a/src/stories/atoms/Button/button.module.css
+++ b/src/stories/atoms/Button/button.module.css
@@ -137,3 +137,7 @@
 .a_button__radius {
   border-radius: 3em;
 }
+
+.a_button__full {
+  width: 100%;
+}


### PR DESCRIPTION
# 概要

- [x] [⚡ Buttonコンポーネントでwidth: 100%が指定できるように](https://github.com/PenPeen/react_storybook/commit/8d25ceee4e4f32ce4afba52347501442e5a156e6)

<img width="701" alt="image" src="https://github.com/user-attachments/assets/09449cb5-655f-412f-8051-74574a6eaac2">
